### PR TITLE
Fix/update to cert manager 0.12

### DIFF
--- a/deploy/alidns-webhook/Chart.yaml
+++ b/deploy/alidns-webhook/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: alidns-webhook
-version: 0.1.0
+version: 0.1.1

--- a/deploy/alidns-webhook/templates/deployment.yaml
+++ b/deploy/alidns-webhook/templates/deployment.yaml
@@ -50,6 +50,10 @@ spec:
               readOnly: true
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+{{ if .Values.image.privateRegistry.enabled }}
+      imagePullSecrets:
+        - name: {{ .Values.image.privateRegistry.dockerRegistrySecret }}
+{{ end }}
       volumes:
         - name: certs
           secret:

--- a/deploy/alidns-webhook/templates/pki.yaml
+++ b/deploy/alidns-webhook/templates/pki.yaml
@@ -1,7 +1,7 @@
 ---
 # Create a selfsigned Issuer, in order to create a root CA certificate for
 # signing webhook serving certificates
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: {{ include "alidns-webhook.selfSignedIssuer" . }}
@@ -17,7 +17,7 @@ spec:
 ---
 
 # Generate a CA Certificate used to sign certificates for the webhook
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: {{ include "alidns-webhook.rootCACertificate" . }}
@@ -38,7 +38,7 @@ spec:
 ---
 
 # Create an Issuer that uses the above generated CA certificate to issue certs
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: {{ include "alidns-webhook.rootCAIssuer" . }}
@@ -55,7 +55,7 @@ spec:
 ---
 
 # Finally, generate a serving certificate for the webhook to use
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: {{ include "alidns-webhook.servingCertificate" . }}

--- a/deploy/alidns-webhook/values.yaml
+++ b/deploy/alidns-webhook/values.yaml
@@ -16,6 +16,9 @@ image:
   repository: mycompany/webhook-image
   tag: latest
   pullPolicy: IfNotPresent
+  privateRegistry:
+    enabled: false
+    dockerRegistrySecret: alibaba-container-registry
 
 nameOverride: ""
 fullnameOverride: ""
@@ -24,7 +27,8 @@ service:
   type: ClusterIP
   port: 443
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
Hello Olivier,

I made the following modification on your project because I am trying to deploy your project on my k8s cluster on alicloud.

Here are my modifications:
- Cert managet 0.12 relocate cert-manager APIs. So I changed the location of these APIs.
- I also introduced new values in helm chart to enable private registry image pulling by providing secret name that contains docker credentials.

David