### PR TITLE
Update deployment api group to v1

### DIFF
--- a/charts/alidns-webhook/templates/deployment.yaml
+++ b/charts/alidns-webhook/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "alidns-webhook.fullname" . }}

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ type aliDNSProviderConfig struct {
 
 	AccessToken cmmetav1.SecretKeySelector `json:"accessTokenSecretRef"`
 	SecretToken cmmetav1.SecretKeySelector `json:"secretKeySecretRef"`
-	Regionid    string                 `json:"regionId"`
+	Regionid    string                     `json:"regionId"`
 }
 
 // Name is used as the name for this DNS solver when referencing it on the ACME
@@ -108,6 +108,9 @@ func (c *aliDNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) error {
 	fmt.Printf("Decoded configuration: %v\n", cfg)
 
 	accessToken, err := c.loadSecretData(cfg.AccessToken, ch.ResourceNamespace)
+	if err != nil {
+		return err
+	}
 	secretKey, err := c.loadSecretData(cfg.SecretToken, ch.ResourceNamespace)
 	if err != nil {
 		return err
@@ -117,6 +120,9 @@ func (c *aliDNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) error {
 	credential := credentials.NewAccessKeyCredential(string(accessToken), string(secretKey))
 
 	client, err := alidns.NewClientWithOptions(cfg.Regionid, conf, credential)
+	if err != nil {
+		return err
+	}
 	c.aliDNSClient = client
 
 	_, zoneName, err := c.getHostedZone(ch.ResolvedZone)


### PR DESCRIPTION
Currently it's not possible to deploy the helm charts on k8s 1.21 . The api group should be changed from v1beta2 to v1

Also some other minor changes for better error handling.