### PR TITLE
feat(chart): add securePort option

### DIFF
--- a/charts/alidns-webhook/Chart.yaml
+++ b/charts/alidns-webhook/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.2.0"
 description: Deploys alidns webhook for cert-manager. 
 name: alidns-webhook
-version: 0.3.0
+version: 0.4.0

--- a/charts/alidns-webhook/templates/deployment.yaml
+++ b/charts/alidns-webhook/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "alidns-webhook.fullname" . }}

--- a/charts/alidns-webhook/templates/deployment.yaml
+++ b/charts/alidns-webhook/templates/deployment.yaml
@@ -27,12 +27,13 @@ spec:
           args:
             - --tls-cert-file=/tls/tls.crt
             - --tls-private-key-file=/tls/tls.key
+            - --secure-port={{ .Values.securePort }}
           env:
             - name: GROUP_NAME
               value: {{ .Values.groupName | quote }}
           ports:
             - name: https
-              containerPort: 443
+              containerPort: {{ .Values.securePort }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/alidns-webhook/values.yaml
+++ b/charts/alidns-webhook/values.yaml
@@ -23,6 +23,8 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+securePort: 443
+
 service:
   type: ClusterIP
   port: 443

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ type aliDNSProviderConfig struct {
 
 	AccessToken cmmetav1.SecretKeySelector `json:"accessTokenSecretRef"`
 	SecretToken cmmetav1.SecretKeySelector `json:"secretKeySecretRef"`
-	Regionid    string                 `json:"regionId"`
+	Regionid    string                     `json:"regionId"`
 }
 
 // Name is used as the name for this DNS solver when referencing it on the ACME
@@ -108,6 +108,9 @@ func (c *aliDNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) error {
 	fmt.Printf("Decoded configuration: %v\n", cfg)
 
 	accessToken, err := c.loadSecretData(cfg.AccessToken, ch.ResourceNamespace)
+	if err != nil {
+		return err
+	}
 	secretKey, err := c.loadSecretData(cfg.SecretToken, ch.ResourceNamespace)
 	if err != nil {
 		return err
@@ -117,6 +120,9 @@ func (c *aliDNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) error {
 	credential := credentials.NewAccessKeyCredential(string(accessToken), string(secretKey))
 
 	client, err := alidns.NewClientWithOptions(cfg.Regionid, conf, credential)
+	if err != nil {
+		return err
+	}
 	c.aliDNSClient = client
 
 	_, zoneName, err := c.getHostedZone(ch.ResolvedZone)


### PR DESCRIPTION
Currently the webhook container is running on port 443. However in environments with extra security policies (such as Openshift), it's not possible to run a container on ports lower than 1024 (unless providing additional security constraints which requires admin privileges). So there should be an option to specify the container port (in our case to some number higher than 1024).

This PR does not change any behavior and is fully backward-compatible.

Tested on Openshift 4.7.