### PR TITLE
Allow to read secrets in all namespaces (fixes #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,35 +23,34 @@ kubectl create secret generic alidns-secrets --from-literal="access-token=yourto
 
 The name of solver to use is `alidns-solver`. You can create an issuer as below :
 ```
-apiVersion: v1
-items:
-- apiVersion: cert-manager.io/v1
-  kind: Issuer
-  metadata:
-    name: letsencrypt
-    namespace: default
-  spec:
-    acme:
-      email: contact@example.com
-      privateKeySecretRef:
-        name: letsencrypt
-      server: https://acme-v02-staging.api.letsencrypt.org/directory
-      solvers:
-      - dns01:
-          webhook:
-            config:
-              accessTokenSecretRef:
-                key: access-token
-                name: alidns-secrets
-              regionId: cn-beijing
-              secretKeySecretRef:
-                key: secret-key
-                name: alidns-secrets
-            groupName: example.com
-            solverName: alidns-solver
-        selector:
-          dnsNames:
-          - '*.example.com'
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt
+  namespace: default
+spec:
+  acme:
+    email: contact@example.com
+    privateKeySecretRef:
+      name: letsencrypt
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    solvers:
+    - dns01:
+        webhook:
+          config:
+            accessTokenSecretRef:
+              key: access-token
+              name: alidns-secrets
+            regionId: cn-beijing
+            secretKeySecretRef:
+              key: secret-key
+              name: alidns-secrets
+          groupName: example.com
+          solverName: alidns-solver
+      selector:
+        dnsNames:
+        - example.com
+        - '*.example.com'
 ```
 
 Or you can create an ClusterIssuer as below :
@@ -85,7 +84,27 @@ See cert-manager documentation for more information : https://cert-manager.io/do
 
 ### Create the certification
 
-Create an certification using ClusterIssuer as below :
+Then create the certificate which will use this issuer : https://cert-manager.io/docs/usage/certificate/
+
+
+Create an certification using Issuer as below :
+```
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: example-tls
+spec:
+  secretName: example-com-tls
+  commonName: example.com
+  dnsNames:
+  - example.com
+  - "*.example.com"
+  issuerRef:
+    name: letsencrypt
+    kind: Issuer
+```
+
+Or create an certification using ClusterIssuer as below :
 ```
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -102,7 +121,7 @@ spec:
     kind: ClusterIssuer
 ```
 
-Then create the certificate which will use this issuer : https://cert-manager.io/docs/usage/certificate/
+
 
 ## Tests
 

--- a/charts/alidns-webhook/Chart.yaml
+++ b/charts/alidns-webhook/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.2.0"
 description: Deploys alidns webhook for cert-manager.
 name: alidns-webhook
-version: 0.6.0
+version: 0.6.1

--- a/charts/alidns-webhook/templates/rbac.yaml
+++ b/charts/alidns-webhook/templates/rbac.yaml
@@ -8,12 +8,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 ---
-# Grant permissions to read secrets inside the cert-manager namespace to get credentials
+# Grant permissions to read secrets inside the cluster to allow to have issuer in another namespace than the webhook
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: {{ include "alidns-webhook.fullname" . }}:secrets-reader
-  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "alidns-webhook.name" . }}
     chart: {{ include "alidns-webhook.chart" . }}
@@ -27,12 +26,11 @@ rules:
     verbs:
       - 'get'
 ---
-# Bind the previously created role to the webhook service account to allow reading from secrets in a cert-manager namespace
+# Bind the previously created role to the webhook service account to allow reading from secrets in all namespaces
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ include "alidns-webhook.fullname" . }}:secrets-reader
-  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "alidns-webhook.name" . }}
     chart: {{ include "alidns-webhook.chart" . }}
@@ -40,7 +38,7 @@ metadata:
     heritage: {{ .Release.Service }}    
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: {{ include "alidns-webhook.fullname" . }}:secrets-reader
 subjects:
   - apiGroup: ""

--- a/charts/alidns-webhook/values.yaml
+++ b/charts/alidns-webhook/values.yaml
@@ -6,7 +6,7 @@
 # solve the DNS01 challenge.
 # This group name should be **unique**, hence using your own company's domain
 # here is recommended.
-groupName: acme.mycompany.com
+groupName: example.com
 
 certManager:
   namespace: cert-manager


### PR DESCRIPTION
to allow to have issuer & secrets in other namespace than alidns-webhook