### PR TITLE
Replace the certificate interface server because the CA applied for b…

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ spec:
     email: contact@example.com
     privateKeySecretRef:
       name: letsencrypt
-    server: https://acme-staging-v02.api.letsencrypt.org/directory
+#    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    server: https://acme-v02.api.letsencrypt.org/directory
     solvers:
     - dns01:
         webhook:
@@ -62,7 +63,8 @@ metadata:
 spec:
   acme:
     email: contact@example.com
-    server: https://acme-staging-v02.api.letsencrypt.org/directory
+#    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       name: letsencrypt
     solvers:


### PR DESCRIPTION
…y the original interface is expired(2021/1/30) and cannot be used.
原来接口申请的证书浏览器会报“ERR_CERT_AUTHORITY_INVALID”错误，是因原CA证书的过期不能再使用了。https://letsencrypt.org/zh-cn/docs/dst-root-ca-x3-expiration-september-2021/