### PR TITLE
fix: use LastIndex in extractRecordName

### DIFF
--- a/main.go
+++ b/main.go
@@ -279,7 +279,7 @@ func (c *aliDNSProviderSolver) findTxtRecords(domain string, fqdn string) ([]ali
 
 func (c *aliDNSProviderSolver) extractRecordName(fqdn, domain string) string {
 	name := util.UnFqdn(fqdn)
-	if idx := strings.Index(name, "."+domain); idx != -1 {
+	if idx := strings.LastIndex(name, "."+domain); idx != -1 {
 		return name[:idx]
 	}
 	return name


### PR DESCRIPTION
When extracting the record name for the `TXT` record, the `extractRecordName` should remove the zone name from the `fqdn` if it exists. 

However, if the `fqdn` contains several occurrences of the zone name, the method cuts the `fqdn` in the first occurrence instead of the last. Using `LastIndex` instead of `Index` should fix this issue.

Example:
`fqdn` - _acme-challenge.dcc9.public-interface.alias.chwun.dev.**ugw.sapcloud.cn**.alias.chwun.dev.**ugw.sapcloud.cn**
`zone` - ugw.sapcloud.cn

The expected record name is _acme-challenge.dcc9.public-interface.alias.chwun.dev.ugw.sapcloud.cn.alias.chwun.dev
The current implementaion returns _acme-challenge.dcc9.public-interface.alias.chwun.dev